### PR TITLE
[IP-XXX] fetch slug size via slug endpoint

### DIFF
--- a/app/services/deploy_fetcher/heroku_adapter.rb
+++ b/app/services/deploy_fetcher/heroku_adapter.rb
@@ -13,13 +13,15 @@ module DeployFetcher
       client.release.list(ENV.fetch('HEROKU_APP')).each do |release|
         next unless release['description'] =~ /^Deploy ([0-9a-f]+)$/
         commit_hash = $1
+        slug = client.slug.info(ENV['HEROKU_APP'], release['slug']['id'])
+
         yield [{
           'created_at'      => release['created_at'],
           'revision'        => commit_hash,
           'repository'      => ENV.fetch('GITHUB_REPO'),
           'local_username'  => release['user']['email'],
           'environment'     => 'production', # DeployImporter expects this
-          'artifact_size'   => release['slug']['size'],
+          'artifact_size'   => slug['size'],
         }]
         @logger.log(".", newline: false)
       end


### PR DESCRIPTION
you need a Slug object to get the size, which we now pull separately before yielding