### PR TITLE
Get the slug size in it's own job

### DIFF
--- a/app/services/deploy_fetcher/heroku_adapter.rb
+++ b/app/services/deploy_fetcher/heroku_adapter.rb
@@ -13,7 +13,6 @@ module DeployFetcher
       client.release.list(ENV.fetch('HEROKU_APP')).each do |release|
         next unless release['description'] =~ /^Deploy ([0-9a-f]+)$/
         commit_hash = $1
-        slug = client.slug.info(ENV['HEROKU_APP'], release['slug']['id'])
 
         yield [{
           'created_at'      => release['created_at'],
@@ -21,7 +20,7 @@ module DeployFetcher
           'repository'      => ENV.fetch('GITHUB_REPO'),
           'local_username'  => release['user']['email'],
           'environment'     => 'production', # DeployImporter expects this
-          'artifact_size'   => slug['size'],
+          'slug_id'         => release['slug']['id']
         }]
         @logger.log(".", newline: false)
       end

--- a/app/services/deploy_importer.rb
+++ b/app/services/deploy_importer.rb
@@ -19,9 +19,10 @@ class DeployImporter
           d.repository    = deploy['repository']
           d.username      = deploy['local_username']
           d.environment   = deploy['environment']
-          d.artifact_size = deploy['artifact_size']
           d.missing_sha   = commit_for(d.repository, d.sha).nil?
           d.save!
+
+          SlugInfoFetcher.new(d.id, deploy['slug_id']).delay.fetch_and_update! unless d.artifact_size.present?
         end
       end
     end

--- a/app/services/slug_info_fetcher.rb
+++ b/app/services/slug_info_fetcher.rb
@@ -1,0 +1,19 @@
+require 'platform-api'
+
+class SlugInfoFetcher
+  def initialize(deploy_id, slug_id)
+    @deploy_id = deploy_id
+    @slug_id = slug_id
+  end
+
+  def fetch_and_update!
+    slug = client.slug.info(ENV['HEROKU_APP'], @slug_id)
+
+    Deploy.update(@deploy_id, artifact_size: slug['size']) if slug
+  end
+
+  private
+  def client
+    @client ||= PlatformAPI.connect_oauth ENV.fetch('HEROKU_TOKEN')
+  end
+end


### PR DESCRIPTION
**Why**
The Deploylist app currently records metrics from Heroku r.e. our deploys in it's database for HTTP browsing. These metrics would be valuable to also record in Datadog to allow us to alert when our deploy times/slug size exceed safe levels.

**What**
Getting the deploy  and slug info at the same time made the app too slow, I moved the code to get the slug size into it's own job.